### PR TITLE
fix(button): spacing and box-sizing.

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -317,9 +317,9 @@ section ul{
           appearance: none;
   cursor: pointer;
   white-space: nowrap;
-  line-height: 30px;
-  height: 30px;
-  padding: 0px 7.5px;
+  line-height: 35px;
+  height: 35px;
+  padding: 0px 10px;
   vertical-align: middle;
   border: 0;
   border-radius: 5px;
@@ -336,6 +336,7 @@ section ul{
   -webkit-box-align: center;
       -ms-flex-align: center;
           align-items: center;
+  box-sizing: content-box;
 }
 
 .button:hover {
@@ -513,7 +514,7 @@ section ul{
 
   & .button-text-style {
     font-size: 12px;
-    line-height: 30px;
+    line-height: 35px;
     font-weight: 600;
   }
 

--- a/postcss/button.css
+++ b/postcss/button.css
@@ -16,6 +16,7 @@
   border: 1px solid transparent;
   display: flex;
   align-items: center;
+  box-sizing: content-box;
 }
 
 .button:hover {

--- a/postcss/variables.css
+++ b/postcss/variables.css
@@ -54,9 +54,9 @@
   $button-font-size: 12px;
   $button-line-height: calc($button-font-size * $line-height-multiplier-base);
   $button-font-weight: 600;
-  $button-horizontal-padding: 7.5px;
-  $button-height: 30px;
-  $button-line-height: 30px;
+  $button-horizontal-padding: 10px;
+  $button-height: 35px;
+  $button-line-height: 35px;
 
   $button-font-size-small: 10px;
   $button-font-weight-small: 600;


### PR DESCRIPTION
In the sketch file, the height of the regular button is `35px`.

Also, it wasn't a good idea to apply `box-sizing: border-box` to buttons since I want their borders to be the part of their size. I mean, the buttons with only an icon, should rather form a square.

If you don't believe me, try it out by disabling `box-sizing: content-box` on the `.button` in the dev's toolbar (in case of buttons with only an icon).