### PR TITLE
Remove the npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-registry=https://npm.registry.purposeindustries.co
-//npm.registry.purposeindustries.co/:always-auth=true


### PR DESCRIPTION
we currently have no private deps, so `.npmrc` is not necessary.