### PR TITLE
fix(sidebar): change sidebar item's hover blue to support the wcag 2.0 standard.

### DIFF
--- a/src/postcss/sidebar.css
+++ b/src/postcss/sidebar.css
@@ -46,7 +46,7 @@
     }
 
     &:hover {
-      color: $color-primary-3;
+      color: $color-primary-1;
     }
   }
 


### PR DESCRIPTION
According to the design plan. It has a better contrast ratio, therefore it's readable.