### PR TITLE
fix(SingleAccordion): close on second click of accordion-item

### DIFF
--- a/src/components/accordion/index.js
+++ b/src/components/accordion/index.js
@@ -95,8 +95,7 @@ export class SingleAccordion extends MultiAccordion {
   toggle = (id) => {
     this.setState((state) => {
       const isOpened = Boolean(state.items[id]);
-      let items = state.items;
-      items = {
+      const items = {
         [id]: !isOpened
       };
       return { items };


### PR DESCRIPTION
In your PR, the `<SingleAccordion />` didn't function properly. When I clicked on one of the items, it didn't close itself.