### PR TITLE
fix: remove autogrow textarea from header.

### DIFF
--- a/src/pages/inputs.js
+++ b/src/pages/inputs.js
@@ -46,7 +46,7 @@ export default class Inputs extends Component {
         value: ''
       },
       prefixValue: 'https://facebook.com/',
-      invisibleTitle: 'This is an invisible textarea inside a header',
+      invisibleTitle: 'This is an invisible textarea',
       html: textareaValue,
       selected: []
     };
@@ -398,13 +398,11 @@ export default class Inputs extends Component {
             </Row>
             <Row>
               <Col span={ 6 }>
-                <DisplayText>
-                  <InvisibleAutgrowTextarea
-                    value={ this.state.invisibleTitle }
-                    onChange={ this.handleInputChange }
-                    name="invisibleTitle"
-                  />
-                </DisplayText>
+                <InvisibleAutgrowTextarea
+                  value={ this.state.invisibleTitle }
+                  onChange={ this.handleInputChange }
+                  name="invisibleTitle"
+                />
               </Col>
               <Col span={ 6 }>
                 <RichTextarea
@@ -417,14 +415,12 @@ export default class Inputs extends Component {
             </Row>
             <Row>
               <Col span={ 6 }>
-                <DisplayText>
-                  <InvisibleAutgrowTextarea
-                    disabled
-                    value={ this.state.invisibleTitle }
-                    onChange={ this.handleInputChange }
-                    name="invisibleTitle"
-                  />
-                </DisplayText>
+                <InvisibleAutgrowTextarea
+                  disabled
+                  value={ this.state.invisibleTitle }
+                  onChange={ this.handleInputChange }
+                  name="invisibleTitle"
+                />
               </Col>
               <Col span={ 6 }>
                 <RichTextarea


### PR DESCRIPTION
we don't put stuff like that in a header.

`Warning: validateDOMNesting(...): <div> cannot appear as a descendant of <p>. See Inputs > DisplayText > p > ... > Autogrow > div.`