### PR TITLE
fix(autogrow textarea): remove setTimeout.

### DIFF
--- a/src/components/textarea/index.js
+++ b/src/components/textarea/index.js
@@ -58,7 +58,7 @@ const autogrow = Component => class AutogrowingComponent extends React.Component
     height: null,
   };
 
-  adjustHeight(nextFrame) {
+  adjustHeight() {
     const adjust = () => {
       if (this.state.height === (this._el && this._el.scrollHeight)) {
         return;
@@ -67,36 +67,26 @@ const autogrow = Component => class AutogrowingComponent extends React.Component
         height: this._el && this._el.scrollHeight,
       });
     };
+    adjust();
+  }
 
-    if (nextFrame) {
-      this.timeoutId = setTimeout(adjust, 0);
-    } else {
-      adjust();
-    }
+  componentDidMount() {
+    this.adjustHeight();
   }
 
   componentDidUpdate() {
     this.adjustHeight();
   }
 
-  componentWillUnmount() {
-    if (this.timeoutId) {
-      clearTimeout(this.timeoutId);
-      this.timeoutId = null;
-    }
-  }
-
   render() {
-    const store = el => {
-      this._el = el;
-      this.adjustHeight(true);
-    };
     return (
       <div className="autogrow" style={ this.state.height ? { height: this.state.height + 'px' } : null }>
         <div className="autogrow--measurer">
           <Component
             { ...this.props }
-            inputRef={ store }
+            inputRef={ el => {
+              this._el = el;
+            } }
             className={ classNames('autogrow', 'autogrow--measured', this.props.className) }
           />
         </div>


### PR DESCRIPTION
I keep getting the following error when using it in another project:

```
Warning: Can only update a mounted or mounting component. This usually means you called setState, replaceState, or forceUpdate on an unmounted component. This is a no-op.

Please check the code for the Autogrow component.
```

This error tends to appear b/c we have an async `setTimeout` operation but we do the cleaning in `componentWillUnmount` so my hunch is that it's not a good idea to perform an async operation (and `setState`) in the ref callback :D. And nevertheless, it's not necessary.