### PR TITLE
fix(dropdown item): set onclick but avoid passing boolean as a callback.

### DIFF
--- a/src/components/dropdown-item/index.js
+++ b/src/components/dropdown-item/index.js
@@ -10,7 +10,7 @@ export default function DropdownItem(props) {
           'dropdown-item--disabled': !!props.disabled
         })
       }
-      onClick={ !props.disabled && props.onClick }
+      onClick={ !props.disabled ? props.onClick : undefined }
       onMouseDown={ props.onMouseDown }
       id={ props.id }
     >


### PR DESCRIPTION
I've got the following error:
"Expected `onClick` listener to be a function, instead got `false`."