### PR TITLE
fix(avatar): handle falsy src cases and render the silhouette instead.

### DIFF
--- a/src/components/avatar/index.js
+++ b/src/components/avatar/index.js
@@ -33,14 +33,14 @@ const Avatar = (props) => {
         >
           <UserAvatar
             size={ sizes[props.size] || defaultSize }
-            src={ props.src }
+            src={ props.src || silhouette }
             name={ props.name }
           />
         </OverlayTrigger>
       ) : (
         <UserAvatar
           size={ sizes[props.size] || defaultSize }
-          src={ props.src }
+          src={ props.src || silhouette }
           name={ props.name }
         />
       ) }


### PR DESCRIPTION
Unfortunately sometimes we give null as src to the avatar component. It makes the avatar component render the initials because it has a name and no src so it falls back and renders the initials which is the default behaviour of UserAvatar we use behind the scene. But we don't want to see the initials anymore.