### PR TITLE
fix(Button): set box-sizing to border-box

### DIFF
--- a/src/postcss/button.css
+++ b/src/postcss/button.css
@@ -16,7 +16,6 @@
   border: 1px solid transparent;
   display: flex;
   align-items: center;
-  box-sizing: content-box;
 }
 
 .button:hover {


### PR DESCRIPTION
Norbi complained about not having the same heights between components. Setting back `box-sizing: border-box;` fixed the issue. Only the Button component used `box-sizing: content-box;`. 