### PR TITLE
test: ignore colors in e2e

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,16 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@plotly/d3-sankey": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@plotly/d3-sankey/-/d3-sankey-0.5.0.tgz",
+      "integrity": "sha1-si+up0LlglEzXuXZ+6JIdyYHgA8=",
+      "requires": {
+        "d3-array": "1.2.1",
+        "d3-collection": "1.0.4",
+        "d3-interpolate": "1.1.6"
+      }
+    },
     "3d-view": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/3d-view/-/3d-view-2.0.0.tgz",
@@ -25,21 +35,6 @@
         "mouse-wheel": "1.2.0",
         "right-now": "1.0.0"
       }
-    },
-    "@plotly/d3-sankey": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@plotly/d3-sankey/-/d3-sankey-0.5.0.tgz",
-      "integrity": "sha1-si+up0LlglEzXuXZ+6JIdyYHgA8=",
-      "requires": {
-        "d3-array": "1.2.1",
-        "d3-collection": "1.0.4",
-        "d3-interpolate": "1.1.6"
-      }
-    },
-    "JSV": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz",
-      "integrity": "sha1-0Hf2glVx+CEy+d/67Vh7QCn+/1c="
     },
     "a-big-triangle": {
       "version": "1.0.3",
@@ -6965,6 +6960,14 @@
             }
           }
         },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -6973,14 +6976,6 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -10651,6 +10646,11 @@
         "verror": "1.10.0"
       }
     },
+    "JSV": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz",
+      "integrity": "sha1-0Hf2glVx+CEy+d/67Vh7QCn+/1c="
+    },
     "jsx-ast-utils": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-1.4.1.tgz",
@@ -10833,7 +10833,7 @@
         "parse-bmfont-ascii": "1.0.6",
         "parse-bmfont-binary": "1.0.6",
         "parse-bmfont-xml": "1.1.3",
-        "xhr": "2.4.0",
+        "xhr": "2.4.1",
         "xtend": "4.0.1"
       }
     },
@@ -13239,8 +13239,8 @@
       "resolved": "https://registry.npmjs.org/plotly.js/-/plotly.js-1.31.2.tgz",
       "integrity": "sha1-G0EAvGCVf+dYnOcs/M1O5Jnfrts=",
       "requires": {
-        "3d-view": "2.0.0",
         "@plotly/d3-sankey": "0.5.0",
+        "3d-view": "2.0.0",
         "alpha-shape": "1.0.0",
         "color-rgba": "1.1.1",
         "convex-hull": "1.0.3",
@@ -18296,6 +18296,11 @@
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
       "dev": true
     },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+    },
     "string-length": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
@@ -18362,11 +18367,6 @@
         "es-abstract": "1.10.0",
         "function-bind": "1.1.1"
       }
-    },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
     "stringstream": {
       "version": "0.0.5",
@@ -19997,9 +19997,8 @@
       }
     },
     "wdio-visual-regression-service": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/wdio-visual-regression-service/-/wdio-visual-regression-service-0.8.0.tgz",
-      "integrity": "sha1-3OhPm/B6B4O1DCAN94M0b89HVaM=",
+      "version": "https://github.com/purposeindustries/wdio-visual-regression-service/releases/download/ignore-comparison/wdio-visual-regression-service-0.8.0.tgz",
+      "integrity": "sha1-n86kCRnUpWyfblQD0F18FB82MUg=",
       "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
@@ -20407,6 +20406,23 @@
             "hoek": "2.16.3"
           }
         },
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.1.1",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+              "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+              "dev": true
+            }
+          }
+        },
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -20431,23 +20447,6 @@
               "requires": {
                 "ansi-regex": "3.0.0"
               }
-            }
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          },
-          "dependencies": {
-            "safe-buffer": {
-              "version": "5.1.1",
-              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-              "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-              "dev": true
             }
           }
         },
@@ -21480,9 +21479,9 @@
       "dev": true
     },
     "xhr": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.4.0.tgz",
-      "integrity": "sha1-4W5mpF+GmGHu76tBbV7/ci3ECZM=",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.4.1.tgz",
+      "integrity": "sha512-pAIU5vBr9Hiy5cpFIbPnwf0C18ZF86DBsZKrlsf87N5De/JbA6RJ83UP/cv+aljl4S40iRVMqP4pr4sF9Dnj0A==",
       "dev": true,
       "requires": {
         "global": "4.3.2",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "wdio-sauce-service": "^0.4.4",
     "wdio-selenium-standalone-service": "0.0.9",
     "wdio-spec-reporter": "^0.1.3",
-    "wdio-visual-regression-service": "^0.8.0",
+    "wdio-visual-regression-service": "https://github.com/purposeindustries/wdio-visual-regression-service/releases/download/ignore-comparison/wdio-visual-regression-service-0.8.0.tgz",
     "webdriver": "^5.0.0-rc1",
     "webdriverio": "^4.9.11",
     "window-or-global": "^1.0.1"

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -122,6 +122,7 @@ exports.config = {
       screenshotName: getScreenshotName(process.env.E2E_SCREENSHOTS + 'screen/'),
       diffName: getScreenshotName(process.env.E2E_SCREENSHOTS + 'diff/'),
       misMatchTolerance: 3.0,
+      ignoreComparison: 'colors'
     }),
   },
   user: sauceLabsUsername,


### PR DESCRIPTION
apparently wdio does support ignoring colors when comparing images.

Under the hood `wdio-visual-regression-service` uses [`node-resemble-js`](https://github.com/lksv/node-resemble.js) to compare images which supports ignoring images.
Even they have support for it: https://github.com/zinserjan/wdio-visual-regression-service/blob/ddf272edddf46fbde4b01e86804c1449ba580123/src/methods/LocalCompare.js#L71
But the property is missing from the constructor so I forked and I added it. (https://github.com/zinserjan/wdio-visual-regression-service/issues/45)

you can pass `colors` or `antialiasing` and that will be ignored.