### PR TITLE
fix(Button): set font-family explicitly

### DIFF
--- a/src/postcss/button.css
+++ b/src/postcss/button.css
@@ -9,6 +9,7 @@
   border: 0;
   border-radius: 5px;
   color: $button-color-primary;
+  font-family: $font-family-base, sans-serif;
   font-size: $button-font-size;
   font-weight: $button-font-weight;
   background: $button-background-color-primary;


### PR DESCRIPTION
Fix for #215.

I checked every component by hand to find missing font-family rules. It seemed to me that only `Button` needed the rule, but pls let me know if you find one.