### PR TITLE
feat: store test file name

### DIFF
--- a/e2e/utils/visual-regression.js
+++ b/e2e/utils/visual-regression.js
@@ -53,7 +53,9 @@ module.exports.takeScreenshotAndGetWholePageCompareResult = (options) => {
 module.exports.takeScreenShotOfElement = (elementSelector, options) => {
   let misMatchTolerance;
   let ignoreComparisonValue = '';
-
+  if (!options.testDirPath) {
+    options.testDirPath = path.dirname(browser.currentTest);
+  }
   if (!options.testDirPath) {
     console.log("missing argument. The testDirPath is neccessary for visual regression pics (default '__dirname')");
     return false;

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -141,7 +141,8 @@ exports.config = {
     timeout: 99999999
   },
 
-  before: function (capabilities) {
+  before: function (capabilities, tests) {
+    browser.currentTest = tests[0];
     if (capabilities.width && capabilities.height) {
       browser.windowHandleSize({
         width: capabilities.width,


### PR DESCRIPTION
It's up for a debate, but passing the `__dirname` every time seems like too much hassle for me, what do you think about this? the `testDirPath` already added to the browser so we don't need to pass the `__dirname`.