### PR TITLE
docs(overlayTrigger): fix misleading example

### DIFF
--- a/src/components/overlay-trigger/README.md
+++ b/src/components/overlay-trigger/README.md
@@ -10,6 +10,7 @@
 | overlay | node | Supply the preferred component to appear as a Popover |
 | trigger | oneOf(['hover', 'click']) | The user event on which the action is invoked |
 | delay | number | You can choose to apply a delay on the Popover. The default is 800ms. |
+| className | string | Use to specify any additional classes to the component. | 
 
 ## Examples
 
@@ -17,11 +18,10 @@ Use to give rise to your `Popover` passed as `prop` to `overlay`.
 
 ```jsx
 <OverlayTrigger
-  placement="top"
   overlay={
     <Popover>
-  Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-  </Popover> }
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+    </Popover> }
 >
   Hover me!
 </OverlayTrigger>


### PR DESCRIPTION
Component does not accept "placement" prop, so remove it from the example. This fixes #248 issue.