### PR TITLE
exclude e2e assets from npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -10,3 +10,6 @@ postcss.config.js
 public
 s3.js
 yarn.lock
+e2e
+allure-results
+errorShots


### PR DESCRIPTION
I even increased the npm package size limit to 50MB but still, the publish failed.

Then i realized the e2e assets (images, test results, test files, reference images, diffs) were part of the package.