### PR TITLE
fix(Button): add type prop to button

### DIFF
--- a/src/components/button/README.md
+++ b/src/components/button/README.md
@@ -16,6 +16,7 @@ click or tap. They can be used for any type of action, including navigation.
 | icon | node | Set the icon, displayed within the button | `none` |
 | onClick | function | Invokes the default click action | `noop` |
 | className | string | Module aiding multiple class activation | `none` |
+| type | string | This prop defines the type of the button. It can be either `submit`, `reset` or `button`. | `none` |
 
 ## Examples
 

--- a/src/components/button/index.js
+++ b/src/components/button/index.js
@@ -13,6 +13,7 @@ const Button = (props) => (
         [`button--${props.size}`]: true
       })
     }
+    type={ props.type }
     onClick={ (e) => {
       if (!props.disabled) {
         props.onClick(e);
@@ -57,6 +58,7 @@ Button.propTypes = {
   onClick: PropTypes.func,
   className: PropTypes.string,
   active: PropTypes.bool,
+  type: PropTypes.oneOf(['button', 'submit', 'reset']),
 };
 
 Button.defaultProps = {


### PR DESCRIPTION
`Button` didn't pass down `type` prop until now.