### PR TITLE
Feat/selector with image

### DIFF
--- a/src/components/dropdown-item/index.js
+++ b/src/components/dropdown-item/index.js
@@ -22,7 +22,7 @@ export default function DropdownItem(props) {
 DropdownItem.displayName = 'DropdownItem';
 
 DropdownItem.propTypes = {
-  children: PropTypes.string,
+  children: PropTypes.node,
   value: PropTypes.string,
   onClick: PropTypes.func,
   onMouseDown: PropTypes.func,

--- a/src/components/dropdown/index.js
+++ b/src/components/dropdown/index.js
@@ -60,7 +60,10 @@ export default class Dropdown extends React.Component {
       return;
     }
     return this.props.arrow ? this.props.arrow : (
-      <Icon icon="ion-android-arrow-dropdown" />
+      <Icon
+        className="dropdown-arrow"
+        icon="ion-android-arrow-dropdown"
+      />
     );
   }
 

--- a/src/components/icon/index.js
+++ b/src/components/icon/index.js
@@ -2,6 +2,8 @@ import React from 'react';
 import Ionicon from 'react-ionicons';
 import icons from 'react-ionicons/lib/icons';
 import PropTypes from 'prop-types';
+import cx from 'classnames';
+
 
 export {
   icons
@@ -10,19 +12,23 @@ export {
 /*
  * https://github.com/zamarrowski/react-ionicons#api
  */
-const Icon = (props) => (
-  <span
-    className="icon"
-    onClick={ props.onClick }
-  >
-    <Ionicon { ...props } />
-  </span>
-);
+const Icon = (props) => {
+  const { className, ...propsWithoutClassName } = props;
+  return (
+    <span
+      className={ cx('icon', className) }
+      onClick={ props.onClick }
+    >
+      <Ionicon { ...propsWithoutClassName } />
+    </span>
+  );
+};
 
 Icon.displayName = 'Icon';
 
 Icon.propTypes = {
-  onClick: PropTypes.func
+  onClick: PropTypes.func,
+  className: PropTypes.string
 };
 
 export default Icon;

--- a/src/components/select/README.md
+++ b/src/components/select/README.md
@@ -15,6 +15,8 @@ clutter up the interface.
 | onChange | func | Callback when selection is changed |
 | style | obj | Pass styles to the component Expected value: `{}` |
 | label | node | You can write any string which appears above select as a label. |
+| className | string | Use to specify any additional classes to the component. |
+
 
 ## Examples
 

--- a/src/components/select/index.js
+++ b/src/components/select/index.js
@@ -12,6 +12,7 @@ export default class Select extends React.Component {
     style: PropTypes.object,
     icon: PropTypes.element,
     label: PropTypes.node,
+    className: PropTypes.string,
   }
   static defaultProps = {
     onChange: () => {}
@@ -33,7 +34,7 @@ export default class Select extends React.Component {
   }
   render() {
     return (
-      <div className="select-wrapper">
+      <div className={ classNames('select-wrapper', this.props.className) }>
         { this.props.label && (
           <div className="select-label">{ this.props.label }</div>
         ) }

--- a/src/pages/select.js
+++ b/src/pages/select.js
@@ -15,7 +15,9 @@ export default class SelectPage extends React.Component {
   state = {
     selected: [],
     car2: '',
-    car: 'hello'
+    car: 'hello',
+    car3: '',
+    cats: null
   }
 
   handleSelectChange = (value, id) => {
@@ -82,9 +84,11 @@ export default class SelectPage extends React.Component {
           <br /><br />
 
           <Select
-            id="car2"
+            id="car3"
             onChange={ this.handleSelectChange }
-            value={ this.state.car2 }
+            value={ this.state.car3 }
+            className="car-3-selector"
+            label={ <Caption>Select with icons</Caption> }
           >
             <DropdownItem
               value={ '' }
@@ -95,22 +99,79 @@ export default class SelectPage extends React.Component {
             <DropdownItem
               value="hello"
             >
-              <Icon icon="ion-android-happy" /><span>Hello</span>
+              <Icon icon="ion-android-happy" /><span>Mitshubishi</span>
             </DropdownItem>
             <DropdownItem
               value="yeah"
             >
-              <Icon icon="ion-android-locate" /><span>yeah dafdsfa</span>
+              <Icon icon="ion-android-locate" /><span>Lada</span>
             </DropdownItem>
             <DropdownItem
               value="what"
             >
-              <Icon icon="ion-android-microphone-off" /><span>what</span>
+              <Icon icon="ion-android-microphone-off" /><span>Opel</span>
             </DropdownItem>
             <DropdownItem
               value="where"
             >
-              where
+              <Icon icon="ion-android-plane" /><span>Airbus</span>
+            </DropdownItem>
+          </Select>
+
+          <br /><br />
+
+          <Select
+            id="flowers"
+            onChange={ this.handleSelectChange }
+            value={ this.state.flowers }
+            className="flowers-selector"
+            label={ <Caption>Select with images</Caption> }
+          >
+            <DropdownItem
+              value={ null }
+              disabled
+            >
+              Choose an option
+            </DropdownItem>
+            <DropdownItem
+              value="suzy"
+            >
+              <span className="dropdown-img-wrap">
+                <img src="http://lorempixel.com/30/30/cats/1" />
+              </span>
+              <span>
+                Suzy
+              </span>
+            </DropdownItem>
+            <DropdownItem
+              value="lizy"
+            >
+              <span className="dropdown-img-wrap">
+                <img src="http://lorempixel.com/30/30/cats/2" />
+              </span>
+              <span>
+                Lizzy
+              </span>
+            </DropdownItem>
+            <DropdownItem
+              value="lena"
+            >
+              <span className="dropdown-img-wrap">
+                <img src="http://lorempixel.com/30/30/cats/3" />
+              </span>
+              <span>
+                Lena
+              </span>
+            </DropdownItem>
+            <DropdownItem
+              value="rob"
+            >
+              <span className="dropdown-img-wrap">
+                <img src="http://lorempixel.com/30/30/cats/4" />
+              </span>
+              <span>
+                Rob
+              </span>
             </DropdownItem>
           </Select>
 

--- a/src/pages/select.js
+++ b/src/pages/select.js
@@ -6,6 +6,7 @@ import DropdownItem from '../components/dropdown-item';
 import OptionSeparator from '../components/option-separator';
 import Option from '../components/option';
 import Caption from '../components/caption';
+import Icon from '../components/icon/';
 
 export default class SelectPage extends React.Component {
 
@@ -70,6 +71,41 @@ export default class SelectPage extends React.Component {
               value="what"
             >
               what
+            </DropdownItem>
+            <DropdownItem
+              value="where"
+            >
+              where
+            </DropdownItem>
+          </Select>
+
+          <br /><br />
+
+          <Select
+            id="car2"
+            onChange={ this.handleSelectChange }
+            value={ this.state.car2 }
+          >
+            <DropdownItem
+              value={ '' }
+              disabled
+            >
+              Choose an option
+            </DropdownItem>
+            <DropdownItem
+              value="hello"
+            >
+              <Icon icon="ion-android-happy" /><span>Hello</span>
+            </DropdownItem>
+            <DropdownItem
+              value="yeah"
+            >
+              <Icon icon="ion-android-locate" /><span>yeah dafdsfa</span>
+            </DropdownItem>
+            <DropdownItem
+              value="what"
+            >
+              <Icon icon="ion-android-microphone-off" /><span>what</span>
             </DropdownItem>
             <DropdownItem
               value="where"

--- a/src/postcss/dropdown.css
+++ b/src/postcss/dropdown.css
@@ -155,6 +155,7 @@ $dropdown-item-bg-color--active: $color-grey-2;
 
     & .dropdown-item,
     & .prefixed-item {
+      position: relative;
       font-size: 12px;
       min-height: 30px;
       cursor: pointer;

--- a/src/postcss/select.css
+++ b/src/postcss/select.css
@@ -28,7 +28,7 @@
 
     }
 
-    & .icon {
+    & .icon.dropdown-arrow {
       position: absolute;
       width: $select-icon-dimension;
       height: $select-icon-dimension;

--- a/src/postcss/select.css
+++ b/src/postcss/select.css
@@ -42,4 +42,13 @@
       fill: $select-svg-fill--hover;
     }
   }
+
+  &.car-3-selector {
+    & .dropdown-item {
+      & .icon {
+        margin-right: 8px;
+      }
+    }
+  }
+
 }


### PR DESCRIPTION
Make the `<Select />` usable for present a list of images and text for the Organization selector:
![image](https://user-images.githubusercontent.com/8988279/36034217-9d6f8e50-0db3-11e8-8f32-245882960a3f.png)
The styling of the list items will be done in the particular usecase. 