### PR TITLE
Feat (tile): implement generic tile

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Here you can find each of our components:
 - [ToggleableTags](/src/components/toggleable-tags)
 - [Tooltip](/src/components/tooltip)
 - [withLimit](/src/components/with-limit)
+- [Tile](/src/components/tile/index)
 
 ## E2E tests usage:
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pi/intellyo-components",
   "description": "Intellyo Application Design System",
-  "version": "7.2.0",
+  "version": "7.3.2-rc1",
   "main": "./dist/index.js",
   "publishConfig": {
     "repository": "https://npm.registry.purposeindustries.co"

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -50,3 +50,4 @@ export { default as Section } from './section';
 export { default as Tab, TabPanel } from './tab-panel';
 export { default as List } from './list';
 export { default as DragSort } from './list/dragSort';
+export { default as Tile } from './tile/';

--- a/src/components/tile/README.md
+++ b/src/components/tile/README.md
@@ -1,0 +1,46 @@
+# Tile
+
+`Tile component` can contain image, icon or solid color with 3 different size and 3 different shape.
+
+## Props
+
+| Prop | Type | Description |
+| ---- | ---- | ----------- |
+| image | string | The url of the image |
+| icon | node | You can pass an icon as node here |
+| color | string | Color of solid brackground in hex or with color name. This background is visible under transparent png or icon.
+| size | string: `small`, `medium`, `large` | Size of the tile |
+| shape | string: `circle`, `rounded`, `square` | Shape of the tile |
+| style | object | Object of css properties and values in camel case format for custom styling |
+| className | string | Custom className for tile wrapper div |
+
+## Examples
+
+```
+<Tile
+    size="small"
+    color="green"
+/>
+
+<Tile
+    icon={ <Icon icon="ion-android-alarm-clock" color="red" /> }
+    color="#CCC"
+/>
+
+<Tile
+    size="large"
+    image="/assets/image.jpg"
+/>
+
+<Tile
+    size="large"
+    color="#CCC"
+    shape="circle"
+/>
+
+<Tile
+    size="large"
+    color="#CCC"
+    shape="square"
+/>
+```

--- a/src/components/tile/index.js
+++ b/src/components/tile/index.js
@@ -6,17 +6,31 @@ class Tile extends React.Component {
 
   static propTypes = {
     image: PropTypes.string,
-    icon: PropTypes.string,
+    icon: PropTypes.node,
+    color: PropTypes.string,
     size: PropTypes.oneOf(['small', 'medium', 'large']),
     shape: PropTypes.oneOf(['circle', 'rounded', 'square']),
   }
 
+  static defaultProps = {
+    size: 'medium',
+    shape: 'rounded',
+    color: 'grey',
+    icon: null,
+  }
+
   render() {
+    const style = {
+      backgroundColor: this.props.color,
+      backgroundImage: this.props.image ? `url(${this.props.image})` : 'no-image'
+    };
+
     return (
       <div
         className={ cx('intellyo-tile', `tile-${this.props.size}`, `tile-${this.props.shape}`) }
+        style={ style }
       >
-        Hello
+        { this.props.icon }
       </div>
     );
   }

--- a/src/components/tile/index.js
+++ b/src/components/tile/index.js
@@ -18,7 +18,7 @@ class Tile extends React.Component {
   static defaultProps = {
     size: 'medium',
     shape: 'rounded',
-    color: 'grey',
+    color: '#E6E6E6',
     icon: null,
   }
 

--- a/src/components/tile/index.js
+++ b/src/components/tile/index.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import cx from 'classnames';
+
+class Tile extends React.Component {
+
+  static propTypes = {
+    image: PropTypes.string,
+    icon: PropTypes.string,
+    size: PropTypes.oneOf(['small', 'medium', 'large']),
+    shape: PropTypes.oneOf(['circle', 'rounded', 'square']),
+  }
+
+  render() {
+    return (
+      <div
+        className={ cx('intellyo-tile', `tile-${this.props.size}`, `tile-${this.props.shape}`) }
+      >
+        Hello
+      </div>
+    );
+  }
+}
+
+export default Tile;

--- a/src/components/tile/index.js
+++ b/src/components/tile/index.js
@@ -10,7 +10,10 @@ class Tile extends React.Component {
     color: PropTypes.string,
     size: PropTypes.oneOf(['small', 'medium', 'large']),
     shape: PropTypes.oneOf(['circle', 'rounded', 'square']),
+    style: PropTypes.object,
+    className: PropTypes.string,
   }
+
 
   static defaultProps = {
     size: 'medium',
@@ -21,13 +24,14 @@ class Tile extends React.Component {
 
   render() {
     const style = {
+      ...this.props.style,
       backgroundColor: this.props.color,
       backgroundImage: this.props.image ? `url(${this.props.image})` : 'no-image'
     };
 
     return (
       <div
-        className={ cx('intellyo-tile', `tile-${this.props.size}`, `tile-${this.props.shape}`) }
+        className={ cx('intellyo-tile', `tile-${this.props.size}`, `tile-${this.props.shape}`, this.props.className) }
         style={ style }
       >
         { this.props.icon }

--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -73,6 +73,9 @@ const TemplateWrapper = ({ children }) => (
             <SidebarItem key="sidebar-item-lists" href="/lists">
               Lists
             </SidebarItem>,
+            <SidebarItem key="sidebar-item-tiles" href="/tiles">
+              Tiles
+            </SidebarItem>,
           ]) }
         >
           Components

--- a/src/pages/tiles.js
+++ b/src/pages/tiles.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import Tile from '../components/tile/';
+
+export default class TilesPage extends React.Component {
+  static displayName = 'TilesPage';
+
+  render() {
+    return <Tile />;
+  }
+}

--- a/src/pages/tiles.js
+++ b/src/pages/tiles.js
@@ -1,10 +1,42 @@
 import React from 'react';
 import Tile from '../components/tile/';
+import Icon from '../components/icon/';
 
 export default class TilesPage extends React.Component {
   static displayName = 'TilesPage';
 
   render() {
-    return <Tile />;
+    return (
+      <div>
+        <Tile
+          size="small"
+          color="green"
+        />
+        <br /><br />
+
+        <Tile
+          icon={ <Icon icon="ion-android-alarm-clock" color="red" /> }
+          color="#CCC"
+        />
+        <br /><br />
+
+        <Tile
+          size="large"
+          image="http://az616578.vo.msecnd.net/files/2016/11/10/6361441079692610831635571641_nast.jpg"
+        />
+
+        <Tile
+          size="large"
+          color="#CCC"
+          shape="circle"
+        />
+
+        <Tile
+          size="large"
+          color="#CCC"
+          shape="square"
+        />
+      </div>
+    );
   }
 }

--- a/src/postcss/main.css
+++ b/src/postcss/main.css
@@ -40,6 +40,7 @@
 @import './section';
 @import './tab-panel';
 @import './list';
+@import './tile';
 
 @import './pages/typography.css';
 @import './pages/grid.css';

--- a/src/postcss/tile.css
+++ b/src/postcss/tile.css
@@ -1,0 +1,47 @@
+$size-small: 24px;
+$size-medium: 40px;
+$size-large: 118px;
+
+.intellyo-tile {
+    background-position: center;
+    background-size: cover;
+    background-repeat: no-repeat;
+    position: relative;
+    display: inline-block;
+
+    & .icon {
+      width: 100%;
+      height: 100%;
+      display: block;      
+    }
+
+    & svg {
+      width: 100%;
+      height: 100%;
+    }
+
+  &.tile {
+    &-small {
+      width: $size-small;
+      height: $size-small;
+    }
+
+    &-medium {
+      width: $size-medium;
+      height: $size-medium;
+    }    
+
+    &-large {
+      width: $size-large;
+      height: $size-large;
+    }    
+
+    &-rounded {
+      border-radius: 16%; 
+    }
+
+    &-circle {
+      border-radius: 100%;
+    }
+  }
+}


### PR DESCRIPTION
Implement a generic tile component, which can contain image, icon or solid color with 3 different size and 3 different shape like this:

![image](https://user-images.githubusercontent.com/8988279/36370808-510962e8-1560-11e8-88cb-c89f9e2c6cab.png)
