### PR TITLE
fix (overlay trigger): implement click outside

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pi/intellyo-components",
   "description": "Intellyo Application Design System",
-  "version": "7.3.5-rc1",
+  "version": "7.3.4",
   "main": "./dist/index.js",
   "publishConfig": {
     "repository": "https://npm.registry.purposeindustries.co"
@@ -91,7 +91,6 @@
     "classnames": "^2.2.5",
     "debug": "^3.1.0",
     "lodash.throttle": "^4.1.1",
-    "outy": "^0.1.2",
     "plotly.js": "^1.30.0",
     "react-autosuggest": "^9.3.2",
     "react-click-outside": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "outy": "^0.1.2",
     "plotly.js": "^1.30.0",
     "react-autosuggest": "^9.3.2",
+    "react-click-outside": "^3.0.1",
     "react-dnd": "^2.5.4",
     "react-dnd-html5-backend": "^2.5.4",
     "react-hide-at": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pi/intellyo-components",
   "description": "Intellyo Application Design System",
-  "version": "7.3.4",
+  "version": "7.3.5-rc1",
   "main": "./dist/index.js",
   "publishConfig": {
     "repository": "https://npm.registry.purposeindustries.co"

--- a/src/components/overlay-trigger/index.js
+++ b/src/components/overlay-trigger/index.js
@@ -79,7 +79,6 @@ class OverlayTrigger extends React.Component {
   componentWillUnmount() {
     window.removeEventListener('keydown', this.onKeyDown);
     this.removeTimer();
-    this.outsideTap.remove();
   }
 
   render() {

--- a/src/components/overlay-trigger/index.js
+++ b/src/components/overlay-trigger/index.js
@@ -16,7 +16,8 @@ class OverlayTrigger extends React.Component {
     children: PropTypes.node.isRequired,
     trigger: PropTypes.oneOf(['click', 'hover']),
     className: PropTypes.string,
-    delay: PropTypes.number
+    delay: PropTypes.number,
+    innerRef: PropTypes.func,
   }
 
   static defaultProps = {
@@ -98,10 +99,14 @@ class OverlayTrigger extends React.Component {
         this.deactivate();
       };
     }
-
     return (
       <Manager>
         <div
+          ref={ () => {
+            if (typeof this.props.innerRef === 'function') {
+              this.props.innerRef(this);
+            }
+          } }
           className={
             classNames('overlay-trigger', {
               'overlay-trigger--active': this.state.isActive

--- a/src/components/overlay-trigger/index.js
+++ b/src/components/overlay-trigger/index.js
@@ -3,11 +3,11 @@ import { findDOMNode } from 'react-dom';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { Manager, Target } from 'react-popper';
-import outy from 'outy';
+import enhanceWithClickOutside from 'react-click-outside';
 
 const ESCKeyCode = 27;
 
-export default class OverlayTrigger extends React.Component {
+class OverlayTrigger extends React.Component {
 
   static displayName = 'Overlay Trigger'
 
@@ -68,19 +68,12 @@ export default class OverlayTrigger extends React.Component {
     }
   }
 
-  handleOutSideTap = () => {
-    const elements = [this.target, this.popper].filter(Boolean);
-
-    this.outsideTap = outy(
-      elements,
-      ['click', 'touchstart'],
-      this.deactivate
-    );
+  handleClickOutside = () => {
+    this.deactivate();
   }
 
   componentDidMount() {
     window.addEventListener('keydown', this.onKeyDown);
-    this.handleOutSideTap();
   }
 
   componentWillUnmount() {
@@ -138,3 +131,5 @@ export default class OverlayTrigger extends React.Component {
     );
   }
 }
+
+export default enhanceWithClickOutside(OverlayTrigger);


### PR DESCRIPTION
Popovers will not close on clicking into them, only if you click outside.
Breaking change, as after introducing this bug-fix some popovers will not close automagically on CE.