### PR TITLE
Fix/(confirmation + modal): fix missing export, autoheight

### DIFF
--- a/src/components/index.js
+++ b/src/components/index.js
@@ -51,3 +51,4 @@ export { Tab, TabPanel } from './tab-panel';
 export { default as List } from './list';
 export { default as DragSort } from './list/dragSort';
 export { default as Tile } from './tile/';
+export { default as Confirmation } from './confirmation/';

--- a/src/components/modals/index.js
+++ b/src/components/modals/index.js
@@ -61,7 +61,7 @@ export default class Modal extends React.PureComponent {
         height: 'auto',
       };
     }
-    
+
     return (
       <div
         className={ classnames('modal', {

--- a/src/components/modals/index.js
+++ b/src/components/modals/index.js
@@ -52,6 +52,16 @@ export default class Modal extends React.PureComponent {
   }
 
   render() {
+    let autoHeightStyles = {};
+
+    if (this.props.hasAutoHeight) {
+      autoHeightStyles = {
+        measure: '',
+        width: this.props.width + this.props.measure,
+        height: 'auto',
+      };
+    }
+    
     return (
       <div
         className={ classnames('modal', {
@@ -72,7 +82,10 @@ export default class Modal extends React.PureComponent {
           closeOnEsc
           animation={ this.props.animation }
           onAnimationEnd={ this.handleAnimationEnd }
-          customStyles={ this.props.customStyles }
+          customStyles={ {
+            ...this.props.customStyles,
+            ...autoHeightStyles,
+          } }
           customMaskStyles={ this.props.customMaskStyles }
         >
           { (this.props.title || this.props.header) && (


### PR DESCRIPTION
- fix the missing export of confirmation 
- overwrite `Rodal` default 240px height if FEF modal `hasAutoHeight` is `true`