### PR TITLE
feat(multiselect): add selected label prop for i18n

### DIFF
--- a/src/components/multiselect/README.md
+++ b/src/components/multiselect/README.md
@@ -11,7 +11,8 @@ Multiselect looks like a select, but it supports multiple selection in a dropdow
 | selected | array | The `selected` prop contains all the selected elements. | no |
 | isActive | boolean | As `Multiselect` relies on the `Dropdown` component `isActive` needs to be handled in `Multiselect`'s state to specify, when the dropdown should be open or not. | no |
 | children | node | `Multiselect`'s children are preferably `Option` and `OptionSeparator` components. They are going to be rendered in a `Dropdown`. | no |
-| defaultLabel | string | You can specify the default label of the `Multiselect` component. It's optional. Default value is 'Nothing is selected.' | no |
+| defaultLabel | node | You can specify the default label of the `Multiselect` component. It's optional. Default value is 'Nothing is selected.' | no |
+| selectedLabel | node | you can modify the text of `selected` to something else for e.g. in language version | no |
 
 ## Examples
 

--- a/src/components/multiselect/index.js
+++ b/src/components/multiselect/index.js
@@ -13,12 +13,14 @@ export default class Multiselect extends React.Component {
     selected: array,
     isActive: bool,
     children: node,
-    defaultLabel: string,
+    defaultLabel: node,
+    selectedLabel: node,
   };
 
   static defaultProps = {
     onChange: () => {},
     defaultLabel: 'Nothing selected',
+    selectedLabel: 'selected',
     selected: [],
   }
 
@@ -36,7 +38,12 @@ export default class Multiselect extends React.Component {
     } else if (selected.length === 1) {
       return this._options[selected[0]].props.children;
     }
-    return `${selected.length} selected`;
+    return (
+      <React.Fragment>
+        <span>{ selected.length }</span>
+        <span className="selected-label">{this.props.selectedLabel}</span>
+      </React.Fragment>
+    );
   }
 
   componentWillReceiveProps(props) {

--- a/src/pages/select.js
+++ b/src/pages/select.js
@@ -1,7 +1,9 @@
 import React from 'react';
 import Card from '../components/card';
-import Select from '../components/select';
-import Multiselect from '../components/multiselect';
+import {
+  Select,
+  Multiselect,
+} from '../components';
 import DropdownItem from '../components/dropdown-item';
 import OptionSeparator from '../components/option-separator';
 import Option from '../components/option';
@@ -115,6 +117,7 @@ export default class SelectPage extends React.Component {
             id="dueDate"
             onChange={ this.handleMultiselectChange }
             selected={ this.state.selected }
+            selectedLabel={ <span>picked</span> }
           >
             <Option value="today">Today</Option>
             <Option value="tomorrow">Tomorrow</Option>

--- a/src/postcss/multiselect.css
+++ b/src/postcss/multiselect.css
@@ -9,4 +9,7 @@
        white-space: nowrap;
     }
   }
+  & .selected-label {
+    padding-left: .25em;
+  }
 }


### PR DESCRIPTION
Enable the multiselect to set the word "selected" to some translation. The space between the the number and another note could only be solved by css.