### PR TITLE
fix(TabPanel): add toArray to be able to filter out null children

### DIFF
--- a/src/components/tab-panel/index.js
+++ b/src/components/tab-panel/index.js
@@ -52,7 +52,7 @@ export class TabPanel extends React.Component {
         }) }
       >
         <div className="tab-list">
-          { React.Children.map(this.props.children, (child, index) => (
+          { React.Children.map(React.Children.toArray(this.props.children), (child, index) => (
             <div
               className={ cx('tab-panel-title', {
                 'tab-panel-title--active': this.state.activeIndex === index
@@ -61,7 +61,7 @@ export class TabPanel extends React.Component {
             >
               { child.props.title }
             </div>
-            )) }
+          )) }
         </div>
         { activeTab }
       </div>


### PR DESCRIPTION
`<TabPanel />` shouldn't return any child, which has the value of `null`. Therefore we need to use `React.Children.toArray()`, which removes the `null` elements from `this.props.children`.

Reference can be found [here](https://github.com/facebook/react/issues/4867#issuecomment-143061047).