### PR TITLE
match tag and branch in deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,7 @@ jobs:
           name: Publish new version to npm
           command: |
             # matches v1.2.3-next, or v1.2.3-1
-            if [[ "$CIRCLE_TAG" =~ "^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(\-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)+(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$" ]]; then
+            if [[ "$CIRCLE_TAG$CIRCLE_BRANCH" =~ "^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(\-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)+(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$" ]]; then
               npm publish
             else
               echo "We are not building a tag or the tag is not a valid semver ($CIRCLE_TAG)";
@@ -105,7 +105,7 @@ jobs:
       - run:
           name: Deploy the version
           command: |
-            if [[ "$CIRCLE_TAG" =~ "^v[0-9]+(\.[0-9]+)*$" ]]; then
+            if [[ "$CIRCLE_TAG$CIRCLE_BRANCH" =~ "^v[0-9]+(\.[0-9]+)*$" ]]; then
               npm run deploy
             else
               echo "We are not build a tag, or the tag is not major, minor or patch but preversion"


### PR DESCRIPTION
circleci is soo kind it wrongly sets the environment variable. even though I'm building the tag, it sets the `CIRCLE_BRANCH` env.

So I added the branch to the tag: `$CIRCLE_TAG$CIRCLE_BRANCH`

I could have replaced tag with branch but if they fix in the future, our code will be compatible with that one as well.