### PR TITLE
fix(popover): call deactivate on clickoutside only if opened

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9242,15 +9242,15 @@
       }
     },
     "gm": {
-      "version": "1.23.1",
-      "resolved": "https://registry.npmjs.org/gm/-/gm-1.23.1.tgz",
-      "integrity": "sha1-Lt7rlYCE0PjqeYjl2ZWxx9/BR3c=",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/gm/-/gm-1.23.0.tgz",
+      "integrity": "sha1-gKL+nL8TFRUCSEZERlhGEmn1JmE=",
       "dev": true,
       "requires": {
         "array-parallel": "0.1.3",
         "array-series": "0.1.5",
         "cross-spawn": "4.0.2",
-        "debug": "3.1.0"
+        "debug": "2.2.0"
       },
       "dependencies": {
         "cross-spawn": {
@@ -9262,6 +9262,21 @@
             "lru-cache": "4.1.1",
             "which": "1.3.0"
           }
+        },
+        "debug": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+          "dev": true,
+          "requires": {
+            "ms": "0.7.1"
+          }
+        },
+        "ms": {
+          "version": "0.7.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+          "dev": true
         }
       }
     },
@@ -10458,7 +10473,7 @@
         "mime": "1.6.0",
         "mkdirp": "0.5.1",
         "pixelmatch": "4.0.2",
-        "pngjs": "3.3.2",
+        "pngjs": "3.3.1",
         "read-chunk": "1.0.1",
         "request": "2.83.0",
         "stream-to-buffer": "0.1.0",
@@ -10467,9 +10482,9 @@
       },
       "dependencies": {
         "pngjs": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.3.2.tgz",
-          "integrity": "sha512-bVNd3LMXRzdo6s4ehr4XW2wFMu9cb40nPgHEjSSppm8/++Xc+g0b2QQb+SeDesgfANXbjydOr1or9YQ+pcCZPQ==",
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.3.1.tgz",
+          "integrity": "sha512-ggXCTsqHRIsGMkHlCEhbHhUmNTA2r1lpkE0NL4Q9S8spkXbm4vE9TVmPso2AGYn90Gltdz8W5CyzhcIGg2Gejg==",
           "dev": true
         }
       }
@@ -13020,13 +13035,13 @@
           "dev": true,
           "requires": {
             "sax": "1.2.4",
-            "xmlbuilder": "9.0.7"
+            "xmlbuilder": "9.0.4"
           }
         },
         "xmlbuilder": {
-          "version": "9.0.7",
-          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-          "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
+          "version": "9.0.4",
+          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.4.tgz",
+          "integrity": "sha1-UZy0ymhtAFqEINNJbz8MruzKWA8=",
           "dev": true
         }
       }
@@ -13267,13 +13282,13 @@
       "integrity": "sha1-j0fc7FARtHe2fbA8JDvB8wheiFQ=",
       "dev": true,
       "requires": {
-        "pngjs": "3.3.2"
+        "pngjs": "3.3.1"
       },
       "dependencies": {
         "pngjs": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.3.2.tgz",
-          "integrity": "sha512-bVNd3LMXRzdo6s4ehr4XW2wFMu9cb40nPgHEjSSppm8/++Xc+g0b2QQb+SeDesgfANXbjydOr1or9YQ+pcCZPQ==",
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.3.1.tgz",
+          "integrity": "sha512-ggXCTsqHRIsGMkHlCEhbHhUmNTA2r1lpkE0NL4Q9S8spkXbm4vE9TVmPso2AGYn90Gltdz8W5CyzhcIGg2Gejg==",
           "dev": true
         }
       }
@@ -13387,9 +13402,9 @@
       }
     },
     "platform": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.5.tgz",
-      "integrity": "sha512-TuvHS8AOIZNAlE77WUDiR4rySV/VMptyMfcfeoMgs4P8apaZM3JrnbzBiixKUv+XR6i+BXrQh8WAnjaSPFO65Q==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.4.tgz",
+      "integrity": "sha1-bw+xftqqSPIUQrOpdcBjEw8cPr0=",
       "dev": true
     },
     "pleeease-filters": {
@@ -20177,7 +20192,7 @@
         "babel-runtime": "6.26.0",
         "debug": "2.6.9",
         "fs-extra": "3.0.1",
-        "gm": "1.23.1",
+        "gm": "1.23.0",
         "image-size": "0.5.5",
         "jimp": "0.2.28",
         "lodash": "4.17.4",
@@ -20367,7 +20382,7 @@
         "fs-extra": "3.0.1",
         "lodash": "4.17.4",
         "node-resemble-js": "0.0.5",
-        "platform": "1.3.5",
+        "platform": "1.3.4",
         "wdio-screenshot": "0.6.0"
       },
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9242,15 +9242,15 @@
       }
     },
     "gm": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/gm/-/gm-1.23.0.tgz",
-      "integrity": "sha1-gKL+nL8TFRUCSEZERlhGEmn1JmE=",
+      "version": "1.23.1",
+      "resolved": "https://registry.npmjs.org/gm/-/gm-1.23.1.tgz",
+      "integrity": "sha1-Lt7rlYCE0PjqeYjl2ZWxx9/BR3c=",
       "dev": true,
       "requires": {
         "array-parallel": "0.1.3",
         "array-series": "0.1.5",
         "cross-spawn": "4.0.2",
-        "debug": "2.2.0"
+        "debug": "3.1.0"
       },
       "dependencies": {
         "cross-spawn": {
@@ -9262,21 +9262,6 @@
             "lru-cache": "4.1.1",
             "which": "1.3.0"
           }
-        },
-        "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.1"
-          }
-        },
-        "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-          "dev": true
         }
       }
     },
@@ -10473,7 +10458,7 @@
         "mime": "1.6.0",
         "mkdirp": "0.5.1",
         "pixelmatch": "4.0.2",
-        "pngjs": "3.3.1",
+        "pngjs": "3.3.2",
         "read-chunk": "1.0.1",
         "request": "2.83.0",
         "stream-to-buffer": "0.1.0",
@@ -10482,9 +10467,9 @@
       },
       "dependencies": {
         "pngjs": {
-          "version": "3.3.1",
-          "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.3.1.tgz",
-          "integrity": "sha512-ggXCTsqHRIsGMkHlCEhbHhUmNTA2r1lpkE0NL4Q9S8spkXbm4vE9TVmPso2AGYn90Gltdz8W5CyzhcIGg2Gejg==",
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.3.2.tgz",
+          "integrity": "sha512-bVNd3LMXRzdo6s4ehr4XW2wFMu9cb40nPgHEjSSppm8/++Xc+g0b2QQb+SeDesgfANXbjydOr1or9YQ+pcCZPQ==",
           "dev": true
         }
       }
@@ -13035,13 +13020,13 @@
           "dev": true,
           "requires": {
             "sax": "1.2.4",
-            "xmlbuilder": "9.0.4"
+            "xmlbuilder": "9.0.7"
           }
         },
         "xmlbuilder": {
-          "version": "9.0.4",
-          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.4.tgz",
-          "integrity": "sha1-UZy0ymhtAFqEINNJbz8MruzKWA8=",
+          "version": "9.0.7",
+          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+          "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
           "dev": true
         }
       }
@@ -13282,13 +13267,13 @@
       "integrity": "sha1-j0fc7FARtHe2fbA8JDvB8wheiFQ=",
       "dev": true,
       "requires": {
-        "pngjs": "3.3.1"
+        "pngjs": "3.3.2"
       },
       "dependencies": {
         "pngjs": {
-          "version": "3.3.1",
-          "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.3.1.tgz",
-          "integrity": "sha512-ggXCTsqHRIsGMkHlCEhbHhUmNTA2r1lpkE0NL4Q9S8spkXbm4vE9TVmPso2AGYn90Gltdz8W5CyzhcIGg2Gejg==",
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.3.2.tgz",
+          "integrity": "sha512-bVNd3LMXRzdo6s4ehr4XW2wFMu9cb40nPgHEjSSppm8/++Xc+g0b2QQb+SeDesgfANXbjydOr1or9YQ+pcCZPQ==",
           "dev": true
         }
       }
@@ -13402,9 +13387,9 @@
       }
     },
     "platform": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.4.tgz",
-      "integrity": "sha1-bw+xftqqSPIUQrOpdcBjEw8cPr0=",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.5.tgz",
+      "integrity": "sha512-TuvHS8AOIZNAlE77WUDiR4rySV/VMptyMfcfeoMgs4P8apaZM3JrnbzBiixKUv+XR6i+BXrQh8WAnjaSPFO65Q==",
       "dev": true
     },
     "pleeease-filters": {
@@ -20192,7 +20177,7 @@
         "babel-runtime": "6.26.0",
         "debug": "2.6.9",
         "fs-extra": "3.0.1",
-        "gm": "1.23.0",
+        "gm": "1.23.1",
         "image-size": "0.5.5",
         "jimp": "0.2.28",
         "lodash": "4.17.4",
@@ -20382,7 +20367,7 @@
         "fs-extra": "3.0.1",
         "lodash": "4.17.4",
         "node-resemble-js": "0.0.5",
-        "platform": "1.3.4",
+        "platform": "1.3.5",
         "wdio-screenshot": "0.6.0"
       },
       "dependencies": {

--- a/src/components/overlay-trigger/index.js
+++ b/src/components/overlay-trigger/index.js
@@ -57,10 +57,12 @@ class OverlayTrigger extends React.Component {
   }
 
   deactivate = () => {
-    this.setState({
-      isActive: false
-    });
-    this.removeTimer();
+    if (this.state.isActive === true) {
+      this.setState({
+        isActive: false
+      });
+      this.removeTimer();
+    }
   }
 
   onKeyDown = (e) => {
@@ -70,9 +72,7 @@ class OverlayTrigger extends React.Component {
   }
 
   handleClickOutside = () => {
-    if (this.state.isActive) {
-      this.deactivate();
-    }
+    this.deactivate();
   }
 
   componentDidMount() {
@@ -85,7 +85,6 @@ class OverlayTrigger extends React.Component {
   }
 
   render() {
-    console.trace(1);
     const triggers = {};
     if (this.props.trigger === 'click') {
       triggers.onClick = () => {

--- a/src/components/overlay-trigger/index.js
+++ b/src/components/overlay-trigger/index.js
@@ -70,7 +70,9 @@ class OverlayTrigger extends React.Component {
   }
 
   handleClickOutside = () => {
-    this.deactivate();
+    if (this.state.isActive) {
+      this.deactivate();
+    }
   }
 
   componentDidMount() {
@@ -83,6 +85,7 @@ class OverlayTrigger extends React.Component {
   }
 
   render() {
+    console.trace(1);
     const triggers = {};
     if (this.props.trigger === 'click') {
       triggers.onClick = () => {


### PR DESCRIPTION
without this, every time we click on anywhere in the application, we
enforce all the rendered popovers (all the tooltips, popovers, dropdowns) to re-render themselves unnecessarily.

cc @oroce @gazdagergo 