### PR TITLE
generate changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+CHANGELOG

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "watch:css": "chokidar 'src/postcss/**/*.css' -c 'npm run build:css' --initial -p",
     "prepublish": "npm t && npm run build:css && npm run build:components",
     "serve": "gatsby serve",
-    "clean-test": "find ./e2e/ \\( -name 'diff' -o -name 'screen' -o -name '*browser-compare-visual-regression' \\) -exec rm -r '{}' \\; || exit 0"
+    "clean-test": "find ./e2e/ \\( -name 'diff' -o -name 'screen' -o -name '*browser-compare-visual-regression' \\) -exec rm -r '{}' \\; || exit 0",
+    "version": "conventional-changelog -p angular -i CHANGELOG.md -s -r 0 && git add CHANGELOG.md"
   },
   "devDependencies": {
     "aws-sdk-then": "^1.1.0",
@@ -40,6 +41,7 @@
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-2": "^6.24.1",
     "chokidar-cli": "^1.2.0",
+    "conventional-changelog-cli": "^1.3.21",
     "dateformat": "^3.0.2",
     "eslint": "^3.19.0",
     "eslint-config-pi": "^10.0.0",


### PR DESCRIPTION
the version script was something I was completely unaware of. As it turned out ([docs](https://docs.npmjs.com/cli/version)) if you run `npm version <release type>` the `version` script in your package.json will be called after the version is bumped but before `git commit` is invoked.

I wasn't the genius who came up with this script, I found this here: https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-cli#with-npm-version