### PR TITLE
fix(overlay trigger): remove timer on deactivate whatever the state is.

### DIFF
--- a/src/components/overlay-trigger/index.js
+++ b/src/components/overlay-trigger/index.js
@@ -61,8 +61,8 @@ class OverlayTrigger extends React.Component {
       this.setState({
         isActive: false
       });
-      this.removeTimer();
     }
+    this.removeTimer();
   }
 
   onKeyDown = (e) => {


### PR DESCRIPTION
It could happen that the isActive state property becomes true after a certain delay so I can't remove the timeout listener based on this because I'd like to really deactivate it (shut the timer down) no matter if it's really active or just waiting for becoming active when the timeout listener fires.

The program without this patch can lead to unexpected scenarios when I hover over on the element (which activates the timer because it should appear with delay) and it appears after the delay however I've already left the element with the mouse.