### PR TITLE
ci(rls generation): stop using `npm view`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
 
       - run: npm i --prefer-offline
       
-      - run: npm i -g npm@latest
+      - run: sudo npm i -g npm@latest
 
       - run:
           name: install system wide tools

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,8 @@ jobs:
       - run: echo -e "$NPMRC" >>$HOME/.npmrc
 
       - run: npm i --prefer-offline
+      
+      - run: npm i -g npm@latest
 
       - run:
           name: install system wide tools
@@ -88,7 +90,7 @@ jobs:
               git push --tags
               npm run changelog
               git add CHANGELOG.md
-              VERSION=$(npm view @pi/intellyo-components version -s)
+              VERSION=$(npx -q json -f package.json version)
               git commit -m "rls($VERSION): changelog updated"
               git push -f -u origin master
             else
@@ -135,6 +137,8 @@ jobs:
       - run: echo -e "$NPMRC" >>$HOME/.npmrc
 
       - run: npm i --prefer-offline
+      
+      - run: npm i -g npm@latest
 
       - run:
           name: install system wide tools


### PR DESCRIPTION
`npm view` uses npm to look up the version. Which means the it'll be the latest published but we need the version which is present in the package.json

`npm i -g npm@latest` is needed to make sure we have the [`npx`](https://www.npmjs.com/package/npx)