### PR TITLE
ci: always create latest tag and run e2e test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,6 +88,8 @@ jobs:
               npm version $RELEASE_TYPE --commit-hooks=false
               git push -u origin $CIRCLE_BRANCH
               git push --tags
+              git tag -f vLATEST
+              git push --tags -f
               npm run changelog
               git add CHANGELOG.md
               VERSION=$(npx -q json -f package.json version)
@@ -189,6 +191,9 @@ workflows:
             branches:
               only:
                 - master
+            tags:
+              only:
+                - vLATEST
     jobs:
       - nightly_build
 


### PR DESCRIPTION
Let's start creating new tag, called `vLATEST`, it won't be pushed to npm and won't be deployed. Changelog will ignore it since it wont match the semver.

But we can test the latest release (`vLATEST`) and the next planned one (`master`). 


fyi @ruffle1986 