### PR TITLE
ci: turn off nightly build for latest tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,10 +190,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
-            tags:
-              only:
-                - vLATEST
+                - master            
     jobs:
       - nightly_build
 


### PR DESCRIPTION
I tried multiple options but I was unable to run builds for latest, I raised a question in circleci's discussion platform: https://discuss.circleci.com/t/running-nightly-on-a-specified-git-tag/22406

Let's hope they will get back to me with a solution and I can re-enable this feature because it would handy having this.