### PR TITLE
fix: allow number as dropdownitem's value

### DIFF
--- a/src/components/dropdown-item/index.js
+++ b/src/components/dropdown-item/index.js
@@ -23,7 +23,10 @@ DropdownItem.displayName = 'DropdownItem';
 
 DropdownItem.propTypes = {
   children: PropTypes.node,
-  value: PropTypes.string,
+  value: PropTypes.oneOf([
+    PropTypes.string,
+    PropTypes.number
+  ]),
   onClick: PropTypes.func,
   onMouseDown: PropTypes.func,
   default: PropTypes.bool,


### PR DESCRIPTION
we tend to use `id` which is a number as value. it doesn't make any sense to convert to string and convert it back to number.