### PR TITLE
fix: PropTypes.oneOf expects concrete value, not another PropType

### DIFF
--- a/src/components/dropdown-item/index.js
+++ b/src/components/dropdown-item/index.js
@@ -23,7 +23,7 @@ DropdownItem.displayName = 'DropdownItem';
 
 DropdownItem.propTypes = {
   children: PropTypes.node,
-  value: PropTypes.oneOf([
+  value: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.number
   ]),


### PR DESCRIPTION
What we were looking for is `oneOfType`