### PR TITLE
feat: passing icon to the LoadingButton in non loading state

### DIFF
--- a/src/components/loading-button/index.js
+++ b/src/components/loading-button/index.js
@@ -3,14 +3,14 @@ import Button from '../button';
 import Icon from '../icon';
 import PropTypes from 'prop-types';
 
-const LoadingButton = ({ loading, onClick, size, loadingText, children, disabled, neutral }) => (
+const LoadingButton = ({ loading, onClick, size, loadingText, children, disabled, neutral, icon }) => (
   <Button
     size={ size }
     disabled={ loading || disabled }
     onClick={ onClick }
     icon={ loading ? (
       <Icon icon="ion-load-d" color="#fff" rotate={ true } />
-    ) : null }
+    ) : icon }
     neutral={ neutral }
   >
     { loading ? loadingText : children }
@@ -29,7 +29,8 @@ LoadingButton.propTypes = {
   loadingText: PropTypes.node,
   children: PropTypes.node,
   disabled: PropTypes.bool,
-  neutral: PropTypes.bool
+  neutral: PropTypes.bool,
+  icon: PropTypes.node
 };
 
 export default LoadingButton;


### PR DESCRIPTION
It makes sense to pass icon for the LoadingButton if it isn't in loading state.