### PR TITLE
fix: do not pass `false` to checkbox's onclick handler

### DIFF
--- a/src/components/checkbox/index.js
+++ b/src/components/checkbox/index.js
@@ -5,7 +5,7 @@ import { Icon } from '../index';
 const Checkbox = ({ checked, onChange, disabled }) => (
   <div
     role="checkbox"
-    onClick={ disabled !== true && onChange }
+    onClick={ disabled ? undefined : onChange }
     onKeyDown={ (e) => disabled !== true && e.keyCode === 13 && onChange() }
     aria-checked={ checked }
     aria-disabled={ disabled }


### PR DESCRIPTION
This PR resolves the issue of:

```
Warning: Expected `onClick` listener to be a function, instead got `false`.

If you used to conditionally omit it with onClick={condition && value}, pass onClick={condition ? value : undefined} instead.
    in div (created by Checkbox)
    in Checkbox (created by Calendar)
```